### PR TITLE
Adjust Go stdlib PURLs to better match available data

### DIFF
--- a/commands/internal/prerun/prerun.go
+++ b/commands/internal/prerun/prerun.go
@@ -2,7 +2,7 @@ package prerun
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -12,7 +12,7 @@ import (
 
 // Configure reads and applies the config file if specified
 func Configure(config string, cmd *cobra.Command) bool {
-	file, err := ioutil.ReadFile(config)
+	file, err := os.ReadFile(config)
 	if err != nil {
 		log.Error("unable to read config file: %v", err)
 		return false

--- a/dt/client.go
+++ b/dt/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -95,7 +94,7 @@ func (c *Client) Upload(file io.Reader, project, version, uuid string) (string, 
 		return "", err
 	}
 
-	result, err := ioutil.ReadAll(response.Body)
+	result, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}
@@ -122,7 +121,7 @@ func (c *Client) Version() (string, error) {
 		return "", err
 	}
 
-	result, err := ioutil.ReadAll(response.Body)
+	result, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}
@@ -164,7 +163,7 @@ func (c *Client) Lookup(project, version string) (*Project, error) {
 		return nil, err
 	}
 
-	result, err := ioutil.ReadAll(response.Body)
+	result, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +195,7 @@ func (c *Client) GetProject(uuid string) (*Project, error) {
 		return nil, err
 	}
 
-	result, err := ioutil.ReadAll(response.Body)
+	result, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/dt/client_test.go
+++ b/dt/client_test.go
@@ -2,7 +2,7 @@ package dt
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -67,7 +67,7 @@ func TestUpload(t *testing.T) {
 		}
 
 		file, _, _ := req.FormFile("bom")
-		uploaded, _ := ioutil.ReadAll(file)
+		uploaded, _ := io.ReadAll(file)
 
 		if string(uploaded) != bom {
 			t.Errorf("unexpected bom contents: '%s'", string(uploaded))

--- a/generators/cocoapods/cocoapods.go
+++ b/generators/cocoapods/cocoapods.go
@@ -2,7 +2,7 @@ package cocoapods
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -63,7 +63,7 @@ func (g *Generator) generateComponentsRecursively(path string) ([]*cyclonedx.Com
 	components, _ := generateComponents(path)
 
 	// traverse subdirectories
-	infos, err := ioutil.ReadDir(path)
+	infos, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func buildDependencyChains(component *podComponent, maxDepth int) [][]string {
 }
 
 func readLockfile(path string) (*lockfile, error) {
-	data, err := ioutil.ReadFile(filepath.Join(path, "Podfile.lock"))
+	data, err := os.ReadFile(filepath.Join(path, "Podfile.lock"))
 	if err != nil {
 		return nil, err
 	}

--- a/generators/gomod/gomod.go
+++ b/generators/gomod/gomod.go
@@ -191,7 +191,11 @@ func resolveGoVersion(modules []*cyclonedx.Component) error {
 	for _, module := range modules {
 		if module.Name == "github.com/golang/go" && module.Version == "unknown" {
 			module.Version = version
-			module.PURL = gobom.PURL(gobom.GolangPackage, module.Name, version)
+			// OSS Index has pretty good data for RPM but none for the
+			// PURL "pkg:golang/github.com/golang/go", so as a workaround
+			// just use RPM instead. We don't know what the actual source
+			// of the package is.
+			module.PURL = gobom.PURL(gobom.RpmPackage, "golang", version)
 		}
 	}
 

--- a/generators/gomod/gomod_test.go
+++ b/generators/gomod/gomod_test.go
@@ -78,6 +78,9 @@ func TestGenerateBom(t *testing.T) {
 		(bom.Components[1].Name != "github.com/mattermost/gobom" || bom.Components[0].Name != "github.com/golang/go") {
 		t.Fatalf("unexpected module names in BOM")
 	}
+	if bom.Components[1].PURL != "pkg:rpm/golang@" + bom.Components[1].Version {
+		t.Fatalf("unexpected PURL for Go stdlib")
+	}
 
 	generator.Recurse = true
 	generator.Filters = []string{"release"}

--- a/generators/gradle/gradle.go
+++ b/generators/gradle/gradle.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ func (g *Generator) generateComponentsRecursively(path string) ([]*cyclonedx.Com
 	components, _ := g.generateComponents(path)
 
 	// traverse subdirectories
-	infos, err := ioutil.ReadDir(path)
+	infos, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/generators/gradle/gradle_test.go
+++ b/generators/gradle/gradle_test.go
@@ -3,12 +3,12 @@ package gradle
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestUnmarshal(t *testing.T) {
-	b, err := ioutil.ReadFile("./testdata/gradle-dependencies.txt")
+	b, err := os.ReadFile("./testdata/gradle-dependencies.txt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generators/npm/npm.go
+++ b/generators/npm/npm.go
@@ -3,7 +3,7 @@ package npm
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -183,9 +183,9 @@ func resolveDependants(component *npmComponent) {
 }
 
 func readLockfile(path string) (*lockfile, error) {
-	data, err := ioutil.ReadFile(filepath.Join(path, "package-lock.json"))
+	data, err := os.ReadFile(filepath.Join(path, "package-lock.json"))
 	if err != nil {
-		data, err = ioutil.ReadFile(filepath.Join(path, "npm-shrinkwrap.json"))
+		data, err = os.ReadFile(filepath.Join(path, "npm-shrinkwrap.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +206,7 @@ func readLockfile(path string) (*lockfile, error) {
 	}
 
 	// read package.json if available
-	data, err = ioutil.ReadFile(filepath.Join(path, "package.json"))
+	data, err = os.ReadFile(filepath.Join(path, "package.json"))
 	if err == nil {
 		log.Trace("read 'package.json' in '%s'", path)
 		errUnMarshal := json.Unmarshal(data, &lockfile.manifest)
@@ -227,7 +227,7 @@ func (g *Generator) readLockfiles(path string) (map[string]*lockfile, error) {
 	}
 
 	// traverse subdirectories
-	infos, err := ioutil.ReadDir(path)
+	infos, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/purl.go
+++ b/purl.go
@@ -12,6 +12,7 @@ const (
 	NpmPackage       = "npm"
 	CocoapodsPackage = "cocoapods"
 	GradlePackage    = "maven" // OSS Index doesn't support gradle PURLs so fall back to maven
+	RpmPackage       = "rpm"
 )
 
 // PURL returns a package URL for the specified package type, name, and version


### PR DESCRIPTION
#### Summary
OSS Index has good data for RPM packages of Go but we're currently not getting any of it because gobom uses a different PURL type. This PR overrides the PURL type for the Go stdlib so that it matches the data on OSS Index.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

