### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An extensible [CycloneDX](https://cyclonedx.org/) BOM generator and [Dependency-
 ## Installation
 
 ```
-go get github.com/mattermost/gobom/cmd/gobom
+go install github.com/mattermost/gobom/cmd/gobom@latest
 ```
 
 ## Usage


### PR DESCRIPTION
#### Summary

Update installation instructions

`go get` does not work anymore for newer golang versions.
